### PR TITLE
feat: add dual token columns (Tokens + Cache) for full transparency

### DIFF
--- a/packages/cli/src/commands/rank.ts
+++ b/packages/cli/src/commands/rank.ts
@@ -89,9 +89,9 @@ function printGroup(data: RankResponse, code: string, period: RankingPeriod, con
   console.log(chalk.dim(`  ${period.toUpperCase()} · ${data.start.slice(0, 10)} → ${data.end.slice(0, 10)} · ${data.group.memberCount} members\n`));
 
   const table = new Table({
-    head: ["#", "Name", "Tokens", "Cost", "Chats"].map((h) => chalk.cyan(h)),
+    head: ["#", "Name", "Tokens", "+ Cache", "Cost", "Chats"].map((h) => chalk.cyan(h)),
     style: { head: [], border: [] },
-    colWidths: [5, 20, 10, 12, 8],
+    colWidths: [5, 14, 10, 11, 10, 8],
   });
 
   for (const entry of data.rankings) {
@@ -100,9 +100,12 @@ function printGroup(data: RankResponse, code: string, period: RankingPeriod, con
     const name = isMe ? chalk.green.bold(entry.displayName) : entry.displayName;
     const rankColor = entry.rank <= 3 ? chalk.yellow : chalk.white;
 
+    const tokens = entry.inputTokens + entry.outputTokens;
+
     table.push([
       `${marker}${rankColor(String(entry.rank))}`,
       name,
+      formatTokens(tokens),
       formatTokens(entry.totalTokens),
       `$${entry.costUSD.toFixed(2)}`,
       String(entry.chatCount),

--- a/packages/cli/src/commands/show-data.ts
+++ b/packages/cli/src/commands/show-data.ts
@@ -24,10 +24,16 @@ export async function showDataCommand(): Promise<void> {
 
   for (const block of recent) {
     console.log(chalk.cyan(`  ${block.blockStart.slice(0, 16)} → ${block.blockEnd.slice(11, 16)}`));
-    console.log(chalk.dim(`    tokens: ${block.totalTokens.toLocaleString()}  cost: $${block.costUSD.toFixed(4)}  calls: ${block.entryCount}  models: ${block.models.join(", ")}`));
+    console.log(chalk.dim(`    input: ${block.inputTokens.toLocaleString()}  output: ${block.outputTokens.toLocaleString()}  cache_create: ${block.cacheCreationTokens.toLocaleString()}  cache_read: ${block.cacheReadTokens.toLocaleString()}`));
+    console.log(chalk.dim(`    cost: $${block.costUSD.toFixed(4)}  calls: ${block.entryCount}  models: ${block.models.join(", ")}`));
   }
 
-  const totalTokens = blocks.reduce((s, b) => s + b.totalTokens, 0);
+  const totalInput = blocks.reduce((s, b) => s + b.inputTokens, 0);
+  const totalOutput = blocks.reduce((s, b) => s + b.outputTokens, 0);
+  const totalCacheCreation = blocks.reduce((s, b) => s + b.cacheCreationTokens, 0);
+  const totalCacheRead = blocks.reduce((s, b) => s + b.cacheReadTokens, 0);
   const totalCost = blocks.reduce((s, b) => s + b.costUSD, 0);
-  console.log(chalk.bold(`\n  All-time total: ${totalTokens.toLocaleString()} tokens · $${totalCost.toFixed(2)}`));
+  console.log(chalk.bold(`\n  All-time total: $${totalCost.toFixed(2)}`));
+  console.log(chalk.dim(`    input: ${totalInput.toLocaleString()}  output: ${totalOutput.toLocaleString()}`));
+  console.log(chalk.dim(`    cache_create: ${totalCacheCreation.toLocaleString()}  cache_read: ${totalCacheRead.toLocaleString()}`));
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -87,6 +87,8 @@ export interface RankingEntry {
   totalTokens: number;
   inputTokens: number;
   outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
   costUSD: number;
   models: string[];
   entryCount: number;

--- a/packages/worker/src/dashboard.ts
+++ b/packages/worker/src/dashboard.ts
@@ -124,7 +124,7 @@ function dashboardHTML(code: string) {
 
     @media (max-width: 600px) {
       .wrap { padding: 32px 16px; }
-      th:nth-child(5), td:nth-child(5) { display: none; }
+      th:nth-child(5), td:nth-child(5), th:nth-child(6), td:nth-child(6) { display: none; }
     }
   </style>
 </head>
@@ -239,16 +239,18 @@ function dashboardHTML(code: string) {
 
           var maxCost = 0;
           data.rankings.forEach(function(r) { if (r.costUSD > maxCost) maxCost = r.costUSD; });
-          var h = '<table><thead><tr><th>#</th><th>Name</th><th>Tokens</th><th>Cost</th><th>Chats</th></tr></thead><tbody>';
+          var h = '<table><thead><tr><th>#</th><th>Name</th><th>Tokens</th><th>+ Cache</th><th>Cost</th><th>Chats</th></tr></thead><tbody>';
 
           data.rankings.forEach(function(r) {
             var pct = maxCost > 0 ? (r.costUSD / maxCost * 100) : 0;
             var rankClass = r.rank <= 3 ? "rank top" : "rank";
+            var tokens = r.inputTokens + r.outputTokens;
             h += '<tr>' +
               '<td class="' + rankClass + '">' + r.rank + '</td>' +
               '<td><div class="name-cell">' + avatarHTML(r.userId, r.displayName, r.avatar) +
                 '<div><div class="name-text">' + esc(r.displayName) + '</div>' +
                 '<div class="bar" style="width:' + pct + '%"></div></div></div></td>' +
+              '<td class="tokens">' + formatTokens(tokens) + '</td>' +
               '<td class="tokens">' + formatTokens(r.totalTokens) + '</td>' +
               '<td class="cost">$' + r.costUSD.toFixed(2) + '</td>' +
               '<td class="calls">' + (r.chatCount || 0) + '</td></tr>';

--- a/packages/worker/src/routes/rankings.ts
+++ b/packages/worker/src/routes/rankings.ts
@@ -106,6 +106,8 @@ app.get("/rank/global", async (c) => {
     let totalTokens = 0;
     let inputTokens = 0;
     let outputTokens = 0;
+    let cacheCreationTokens = 0;
+    let cacheReadTokens = 0;
     let costUSD = 0;
     let entryCount = 0;
     let chatCount = 0;
@@ -117,6 +119,8 @@ app.get("/rank/global", async (c) => {
         totalTokens += block.totalTokens;
         inputTokens += block.inputTokens;
         outputTokens += block.outputTokens;
+        cacheCreationTokens += block.cacheCreationTokens || 0;
+        cacheReadTokens += block.cacheReadTokens || 0;
         costUSD += block.costUSD;
         entryCount += block.entryCount;
         chatCount += block.chatCount || 0;
@@ -133,6 +137,8 @@ app.get("/rank/global", async (c) => {
         totalTokens,
         inputTokens,
         outputTokens,
+        cacheCreationTokens,
+        cacheReadTokens,
         costUSD: Math.round(costUSD * 10000) / 10000,
         models: Array.from(models),
         entryCount,
@@ -182,6 +188,8 @@ app.get("/rank/:code", async (c) => {
     let totalTokens = 0;
     let inputTokens = 0;
     let outputTokens = 0;
+    let cacheCreationTokens = 0;
+    let cacheReadTokens = 0;
     let costUSD = 0;
     let entryCount = 0;
     let chatCount = 0;
@@ -194,6 +202,8 @@ app.get("/rank/:code", async (c) => {
           totalTokens += block.totalTokens;
           inputTokens += block.inputTokens;
           outputTokens += block.outputTokens;
+          cacheCreationTokens += block.cacheCreationTokens || 0;
+          cacheReadTokens += block.cacheReadTokens || 0;
           costUSD += block.costUSD;
           entryCount += block.entryCount;
           chatCount += block.chatCount || 0;
@@ -210,6 +220,8 @@ app.get("/rank/:code", async (c) => {
       totalTokens,
       inputTokens,
       outputTokens,
+      cacheCreationTokens,
+      cacheReadTokens,
       costUSD: Math.round(costUSD * 10000) / 10000,
       models: Array.from(models),
       entryCount,


### PR DESCRIPTION
Closes #3

## Problem

After #2 was merged, the "Tokens" column now shows `input + output` only. While accurate, this makes the numbers look small (970K vs the 1B+ that users were seeing before). For a leaderboard tool, bigger numbers = more fun to share.

But just showing `totalTokens` loses the alignment with official Claude Code stats.

## Solution: show both

```
┌─────┬──────────────┬──────────┬───────────┬──────────┬────────┐
│ #   │ Name         │ Tokens   │ + Cache   │ Cost     │ Chats  │
├─────┼──────────────┼──────────┼───────────┼──────────┼────────┤
│ →1  │ BryantChen   │ 970K     │ 1.07B     │ $750.05  │ 480    │
│  2  │ ventuss      │ 398K     │ 394M      │ $332.85  │ 1100   │
└─────┴──────────────┴──────────┴───────────┴──────────┴────────┘
```

- **Tokens** = `input_tokens + output_tokens` (matches Claude Code official stats)
- **+ Cache** = `totalTokens` (all types, the big impressive number)
- **Cost** = per-model × per-type real API pricing (unchanged)

### show-data also improved

```
  2026-02-13T16:00 → 21:00
    input: 15,027  output: 38,666  cache_create: 1,899,362  cache_read: 44,011,140
    cost: $31.2940  calls: 572  models: claude-opus-4-6, ...

  All-time total: $750.05
    input: 648,158  output: 319,864
    cache_create: 51,344,553  cache_read: 1,017,540,221
```

## Changes

| File | What changed |
|------|-------------|
| `shared/types.ts` | Add `cacheCreationTokens` / `cacheReadTokens` to `RankingEntry` |
| `worker/routes/rankings.ts` | Return cache token breakdown from ranking API |
| `cli/commands/rank.ts` | Two columns: "Tokens" (input+output) and "+ Cache" (totalTokens) |
| `cli/commands/show-data.ts` | Show per-type token breakdown |
| `worker/dashboard.ts` | Same dual columns on web dashboard, hide Cost+Chats on mobile |

🤖 Generated with [Claude Code](https://claude.com/claude-code)