### PR TITLE
Change global page back link to My Club

### DIFF
--- a/packages/worker/src/dashboard.ts
+++ b/packages/worker/src/dashboard.ts
@@ -244,7 +244,7 @@ function dashboardHTML(code: string) {
 <body>
   <div class="wrap">
     <div class="top-nav">
-      <a href="/" class="back-link">\u2190 Home</a>
+      <a href="/" class="back-link" id="back-link">\u2190 ${isGlobal ? "My Club" : "Home"}</a>
       ${isGlobal ? html`` : html`<a href="/g/global" class="global-link">Global \u2192</a>`}
     </div>
     <h1 id="title"></h1>
@@ -295,6 +295,18 @@ function dashboardHTML(code: string) {
     var period = "daily";
     var showCache = false;
     var ACTIVE_THRESHOLD_MS = 15 * 60 * 1000;
+
+    // Global page: back link goes to referrer group or fallback to home
+    if (IS_GLOBAL) {
+      var backLink = document.getElementById("back-link");
+      if (backLink) {
+        var ref = document.referrer;
+        var groupMatch = ref && ref.match(/\\/g\\/([a-zA-Z0-9]+)/);
+        if (groupMatch && groupMatch[1].toLowerCase() !== "global") {
+          backLink.href = "/g/" + groupMatch[1];
+        }
+      }
+    }
 
     var cacheToggle = document.getElementById("cache-toggle");
     var cacheLabel = document.getElementById("cache-label");


### PR DESCRIPTION
## Summary
- Global rankings page back link changed from "← Home" to "← My Club"
- Uses `document.referrer` to detect the source group page and link back to it
- Falls back to `/` (home) if no referrer or referrer is not a group page

## Test plan
- [ ] Navigate from a group dashboard → Global → verify "← My Club" links back to that group
- [ ] Open `/g/global` directly → verify "← My Club" falls back to home (`/`)
- [ ] Non-global group pages still show "← Home" as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)