### PR TITLE
fix: avoid misleading rounding in agent mix percentages

### DIFF
--- a/packages/cli/src/commands/rank.ts
+++ b/packages/cli/src/commands/rank.ts
@@ -323,13 +323,21 @@ function colorRoi(roiStr: string, entry: RankingEntry): string {
   return theme.faint(roiStr);
 }
 
+function formatAgentPercent(p: number): string {
+  if (p <= 0) return "0%";
+  if (p >= 100) return "100%";
+  if (p < 1) return "<1%";
+  if (p > 99) return ">99%";
+  return `${Math.round(p)}%`;
+}
+
 function formatAgents(entry: RankingEntry): string {
   if (entry.agentBreakdown && entry.agentBreakdown.length > 0) {
     if (entry.agentBreakdown.length === 1) {
       return formatAgentLabel(entry.agentBreakdown[0].source);
     }
     const visible = entry.agentBreakdown.slice(0, 2)
-      .map((agent) => `${formatAgentLabel(agent.source)} (${agent.percent}%)`);
+      .map((agent) => `${formatAgentLabel(agent.source)} (${formatAgentPercent(agent.percent)})`);
     if (entry.agentBreakdown.length > visible.length) {
       visible.push(`+${entry.agentBreakdown.length - visible.length}`);
     }

--- a/packages/worker/src/dashboard.ts
+++ b/packages/worker/src/dashboard.ts
@@ -680,6 +680,13 @@ function dashboardHTML(code: string, groupName: string, memberCount: number) {
         return { source: source, costUSD: 0, totalTokens: 0, nonCacheTokens: 0, chatCount: 0, entryCount: 0, percent: 0 };
       });
     }
+    function formatAgentPercent(p) {
+      if (p <= 0) return "0%";
+      if (p >= 100) return "100%";
+      if (p < 1) return "<1%";
+      if (p > 99) return ">99%";
+      return Math.round(p) + "%";
+    }
     function agentTooltip(row) {
       if (!row.agentBreakdown || row.agentBreakdown.length === 0) {
         return orderedAgents(row.agents).map(function(source) {
@@ -688,7 +695,7 @@ function dashboardHTML(code: string, groupName: string, memberCount: number) {
       }
       return getAgentBreakdown(row).map(function(agent) {
         var label = AGENT_LABELS[agent.source] || agent.source;
-        var pct = agent.percent ? agent.percent + "% · " : "";
+        var pct = agent.percent ? formatAgentPercent(agent.percent) + " · " : "";
         var cost = agent.costUSD ? "$" + agent.costUSD.toFixed(2) + " · " : "";
         var tokenCount = showCache ? agent.totalTokens : (agent.nonCacheTokens != null ? agent.nonCacheTokens : agent.totalTokens);
         var tokens = tokenCount ? formatTokens(tokenCount) + " tokens · " : "";
@@ -703,7 +710,7 @@ function dashboardHTML(code: string, groupName: string, memberCount: number) {
       var text = breakdown.map(function(agent) {
         var label = esc(AGENT_LABELS[agent.source] || agent.source);
         if (hasBreakdown && breakdown.length > 1) {
-          return '<span class="agent-source">' + label + '</span> <span class="agent-percent">(' + agent.percent + '%)</span>';
+          return '<span class="agent-source">' + label + '</span> <span class="agent-percent">(' + formatAgentPercent(agent.percent) + ')</span>';
         }
         return '<span class="agent-source">' + label + '</span>';
       }).join('<span class="agent-percent">, </span>');

--- a/packages/worker/src/routes/rankings.ts
+++ b/packages/worker/src/routes/rankings.ts
@@ -52,7 +52,7 @@ function buildAgentBreakdown(totals: Map<AgentSource, AgentTotals>, totalCostUSD
         nonCacheTokens: value.nonCacheTokens,
         chatCount: value.chatCount,
         entryCount: value.entryCount,
-        percent: denominator > 0 ? Math.round((numerator / denominator) * 100) : 0,
+        percent: denominator > 0 ? Math.round((numerator / denominator) * 10000) / 100 : 0,
       };
     })
     .sort((a, b) => b.percent - a.percent || b.costUSD - a.costUSD);


### PR DESCRIPTION
## Summary

The dashboard and CLI currently show agent mix percentages rounded to integers. A real share of `0.4%` gets shown as `1%` and a real share of `99.6%` gets shown as `100%`, both of which mislead the reader: `1%` reads as "one in a hundred" when it can be far less, and `100%` implies exclusive use when it isn't.

Example seen in the wild: a member with a few Codex turns sandwiched between a lot of Claude Code work was shown as `Claude Code (99%), Codex (1%)` while the real split was closer to `>99% / <1%`.

This PR:
- keeps two decimals of precision on the `percent` field in the rankings response, so the sort key in `buildAgentBreakdown` keeps working correctly when many agents have small shares
- introduces a small `formatAgentPercent` helper used in `rank.ts` (CLI) and twice in `dashboard.ts` (tooltip + visible agent mix) that renders `<1%`, `>99%`, `100%`, `0%`, or a rounded integer percent at the edges

## Result

```
before:  Claude Code (99%), Codex (1%)
after:   Claude Code (>99%), Codex (<1%)
```

Clean splits like `80%` / `20%` keep displaying the same.

## Notes

- `percent` stays a `number`, so no type change on the API contract.
- All existing tests still pass (`pnpm -r run test`: 20 passed).