### PR TITLE
fix(cli): include Node bin dir in heartbeat LaunchAgent PATH

### DIFF
--- a/packages/cli/src/__tests__/heartbeat.test.ts
+++ b/packages/cli/src/__tests__/heartbeat.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { dirname } from "node:path";
+import { getPlist } from "../heartbeat.js";
+
+describe("getPlist", () => {
+  const plist = getPlist();
+
+  it("prepends the running Node bin dir to PATH so launchd resolves npx/node under nvm/asdf/volta (#18)", () => {
+    const nodeBinDir = dirname(process.execPath);
+    const match = plist.match(/<key>PATH<\/key>\s*<string>([^<]+)<\/string>/);
+    expect(match, "plist must declare a PATH EnvironmentVariable").not.toBeNull();
+
+    const pathValue = match![1];
+    // launchd does not source the user shell profile, so the Node bin dir
+    // (e.g. ~/.nvm/versions/node/<ver>/bin) must be in PATH explicitly,
+    // otherwise `/usr/bin/env npx` fails with "env: npx: No such file or directory".
+    expect(pathValue.startsWith(nodeBinDir)).toBe(true);
+    // System fallbacks are still kept for users on Homebrew / system Node.
+    expect(pathValue).toContain("/usr/local/bin");
+    expect(pathValue).toContain("/usr/bin");
+  });
+
+  it("invokes the heartbeat via /usr/bin/env npx ccclub sync --silent", () => {
+    expect(plist).toContain("/usr/bin/env");
+    expect(plist).toContain("npx");
+    expect(plist).toContain("ccclub");
+    expect(plist).toContain("sync");
+    expect(plist).toContain("--silent");
+  });
+
+  it("schedules the heartbeat every 5 minutes", () => {
+    expect(plist).toContain("<key>StartInterval</key>");
+    expect(plist).toContain("<integer>300</integer>");
+  });
+});

--- a/packages/cli/src/heartbeat.ts
+++ b/packages/cli/src/heartbeat.ts
@@ -1,5 +1,5 @@
 import { writeFile, mkdir } from "node:fs/promises";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { existsSync, readFileSync } from "node:fs";
 import { execFile } from "node:child_process";
@@ -8,9 +8,16 @@ const PLIST_NAME = "dev.ccclub.sync";
 const LAUNCH_AGENTS_DIR = join(homedir(), "Library", "LaunchAgents");
 const PLIST_PATH = join(LAUNCH_AGENTS_DIR, `${PLIST_NAME}.plist`);
 
-function getPlist(): string {
-  // Find the ccclub binary - prefer global npx path
+/**
+ * Build the LaunchAgent plist for the 5-minute heartbeat sync.
+ * @internal exported only so the generated PATH can be unit-tested.
+ */
+export function getPlist(): string {
   const logPath = join(homedir(), ".ccclub", "sync.log");
+  // Prepend the running Node's bin dir so launchd can resolve `npx`/`node`
+  // even when Node is installed via a version manager (nvm/asdf/volta),
+  // whose bin dir is not in the default system PATH. Fixes #18.
+  const pathEnv = `${dirname(process.execPath)}:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin`;
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -36,7 +43,7 @@ function getPlist(): string {
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+    <string>${pathEnv}</string>
   </dict>
 </dict>
 </plist>`;


### PR DESCRIPTION
Fixes #18.

## Problem

The heartbeat LaunchAgent fails with `env: npx: No such file or directory` (exit 127) whenever Node is installed via a version manager (**nvm**/asdf/volta), so the 5-minute background auto-sync effectively never runs — data only reaches the server when `ccclub sync` is run from an interactive shell.

```
$ launchctl list dev.ccclub.sync
"LastExitStatus" = 32512;   // 127 << 7
$ tail ~/.ccclub/sync.log
env: npx: No such file or directory
```

## Root cause

`getPlist()` in `packages/cli/src/heartbeat.ts` invokes `/usr/bin/env npx ccclub sync` but hardcodes `PATH=/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin`. Under nvm/asdf/volta, `npx`/`node` live under a version-scoped bin dir (`~/.nvm/versions/node/<ver>/bin`) that is **not** in that PATH, and launchd does not source the user shell profile — so `/usr/bin/env npx` cannot resolve `npx`.

## Fix

Prepend `dirname(process.execPath)` to the plist PATH so launchd resolves `npx`/`node` regardless of the version manager:

```ts
const pathEnv = `${dirname(process.execPath)}:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin`;
```

Because `isCurrentPlist()` regenerates the plist on divergence, **switching Node versions self-heals** on the next `ccclub` invocation — no migration step needed. Backwards compatible: Homebrew / system-Node users keep the working fallback paths.

## Testing

- New `packages/cli/src/__tests__/heartbeat.test.ts` asserts the PATH starts with `dirname(process.execPath)`, still contains the system fallbacks, and locks in the `ProgramArguments` shape + `StartInterval`.
- `vitest run`: **25 passed (4 files)**.
- Verified end-to-end on nvm + macOS (Darwin 25.5): `LastExitStatus` 127 → 0, and `~/.ccclub/last-sync-time` advances every 5 minutes.

Closes #18.
